### PR TITLE
Update entitlements 96

### DIFF
--- a/appgate/resource_appgate_entitlement_test.go
+++ b/appgate/resource_appgate_entitlement_test.go
@@ -39,7 +39,7 @@ func TestAccEntitlementBasicPing(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.color_code", "5"),
-					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.name", "ping"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.name", rName),
 					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.url", "https://www.google.com"),
 					resource.TestCheckResourceAttr(resourceName, "condition_logic", "and"),
 
@@ -125,12 +125,12 @@ resource "appgate_entitlement" "test_item" {
   }
 
   app_shortcuts {
-    name       = "ping"
+    name       = "%s"
     url        = "https://www.google.com"
     color_code = 5
   }
 }
-`, rName)
+`, rName, rName)
 }
 
 func testAccCheckEntitlementExists(resource string) resource.TestCheckFunc {
@@ -231,12 +231,12 @@ resource "appgate_entitlement" "monitor_entitlement" {
 	}
   
 	app_shortcuts {
-	  name       = "ping"
+	  name       = "%s"
 	  url        = "https://www.google.com"
 	  color_code = 5
 	}
   }
-`, rName)
+`, rName, rName)
 }
 
 func testAccCheckEntitlementWithMonitorUpdated(rName string) string {
@@ -273,10 +273,10 @@ resource "appgate_entitlement" "monitor_entitlement" {
 	}
   
 	app_shortcuts {
-	  name       = "ping"
+	  name       = "%s"
 	  url        = "https://www.google.com"
 	  color_code = 5
 	}
   }
-`, rName)
+`, rName, rName)
 }

--- a/appgate/resource_appgate_entitlement_test.go
+++ b/appgate/resource_appgate_entitlement_test.go
@@ -154,3 +154,129 @@ func testAccCheckEntitlementExists(resource string) resource.TestCheckFunc {
 		return nil
 	}
 }
+
+func TestAccEntitlementBasicWithMonitor(t *testing.T) {
+	resourceName := "appgate_entitlement.monitor_entitlement"
+	rName := RandStringFromCharSet(10, CharSetAlphaNum)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckItemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckEntitlementWithMonitor(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEntitlementExists(resourceName),
+					// default value, computed from the controller, even if we dont set it in the tf
+					// config file, we will get a computed value back.
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.timeout", "30"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccEntitlementImportStateCheckFunc(1),
+			},
+			{
+				Config: testAccCheckEntitlementWithMonitorUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEntitlementExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.timeout", "22"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccEntitlementImportStateCheckFunc(1),
+			},
+		},
+	})
+}
+
+func testAccCheckEntitlementWithMonitor(rName string) string {
+	return fmt.Sprintf(`
+data "appgate_site" "default_site" {
+	   site_name = "Default Site"
+}
+data "appgate_condition" "always" {
+  condition_name = "Always"
+}
+resource "appgate_entitlement" "monitor_entitlement" {
+	name = "%s"
+	site = data.appgate_site.default_site.id
+	conditions = [
+	  data.appgate_condition.always.id
+	]
+  
+	tags = [
+	  "terraform",
+	  "api-created"
+	]
+	disabled = true
+  
+	condition_logic = "and"
+	actions {
+	  action  = "allow"
+	  subtype = "tcp_up"
+	  hosts   = ["192.168.2.255/32"]
+	  ports   = ["53"]
+	}
+  
+	app_shortcuts {
+	  name       = "ping"
+	  url        = "https://www.google.com"
+	  color_code = 5
+	}
+  }
+`, rName)
+}
+
+func testAccCheckEntitlementWithMonitorUpdated(rName string) string {
+	return fmt.Sprintf(`
+data "appgate_site" "default_site" {
+	   site_name = "Default Site"
+}
+data "appgate_condition" "always" {
+  condition_name = "Always"
+}
+resource "appgate_entitlement" "monitor_entitlement" {
+	name = "%s"
+	site = data.appgate_site.default_site.id
+	conditions = [
+	  data.appgate_condition.always.id
+	]
+  
+	tags = [
+	  "terraform",
+	  "api-created"
+	]
+	disabled = true
+  
+	condition_logic = "and"
+	actions {
+	  action  = "allow"
+	  subtype = "tcp_up"
+	  hosts   = ["192.168.2.255/32"]
+	  ports   = ["53"]
+	  monitor {
+		enabled = true
+		timeout = 22
+	  }
+	}
+  
+	app_shortcuts {
+	  name       = "ping"
+	  url        = "https://www.google.com"
+	  color_code = 5
+	}
+  }
+`, rName)
+}


### PR DESCRIPTION
Resolved issue while trying to updated entitlement, this PR fixes #96 

acceptance test
<details>

```

 make testacc
==> Checking that code complies with gofmt requirements...

TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestGetToken200
--- PASS: TestGetToken200 (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (13.30s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (4.06s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (4.84s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (4.90s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (5.01s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (4.50s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
=== PAUSE TestAccClientConnectionsBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (5.37s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (5.75s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccConditionBasic
=== CONT  TestAccClientConnectionsBasic
=== CONT  TestAccBlacklistUserBasic
=== CONT  TestAccadministrativeRoleWithScope
=== CONT  TestAccApplianceConnector
=== CONT  TestAccApplianceBasicController
=== CONT  TestAccApplianceCustomizationBasic
=== CONT  TestAccMfaProviderBasic
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccSiteBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccPolicyBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (20.63s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccEntitlementScriptBasic (23.23s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccClientConnectionsBasic (23.94s)
=== CONT  TestAccLocalUserBasic
--- PASS: TestAccBlacklistUserBasic (25.17s)
=== CONT  TestAccIPPoolBasic
--- PASS: TestAccRingfenceRuleBasicICMP (25.27s)
=== CONT  TestAccSamlIdentityProviderBasic
--- PASS: TestAccadministrativeRoleWithScope (25.37s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccEntitlementBasicPing (25.48s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccConditionBasic (25.98s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccRingfenceRuleBasicTCP (26.00s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccPolicyBasic (26.02s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccApplianceConnector (26.19s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccMfaProviderBasic (26.35s)
=== CONT  TestAccGlobalSettingsBasic
--- PASS: TestAccApplianceCustomizationBasic (26.50s)
--- PASS: TestAccTrustedCertificateBasic (26.56s)
--- PASS: TestAccCriteriaScriptBasic (27.07s)
--- PASS: TestAccDeviceScriptBasic (27.12s)
--- PASS: TestAccApplianceBasicGateway (27.37s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (14.86s)
--- PASS: TestAccAdminMfaSettingsBasic (19.96s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (15.04s)
--- PASS: TestAccAppgateMfaProviderDataSource (15.50s)
--- PASS: TestAccLocalUserBasic (18.05s)
--- PASS: TestAccEntitlementBasicWithMonitor (42.03s)
--- PASS: TestAccGlobalSettingsBasic (16.61s)
--- PASS: TestAccIPPoolBasic (17.87s)
--- PASS: TestAccadministrativeRoleBasic (17.78s)
--- PASS: TestAccRadiusIdentityProviderBasic (20.32s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (18.24s)
--- PASS: TestAccLdapIdentityProviderBasic (18.54s)
--- PASS: TestAccSiteBasic (47.30s)
--- PASS: TestAccApplianceBasicController (48.52s)
--- PASS: TestAccSamlIdentityProviderBasic (31.22s)
PASS
ok  	github.com/appgate/terraform-provider-appgate/appgate	104.264s
```

</details>