### PR TITLE
updated go mod name

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ TF_ACC=1 \
 APPGATE_ADDRESS="https://ec2-54-80-224-21.compute-1.amazonaws.com:444/admin" \
 APPGATE_USERNAME="admin" \
 APPGATE_PASSWORD="admin" \
-go test -v -timeout 120m github.com/appgate/terraform-provider-appgate/appgate -run '^(TestAccApplianceBasicController)$'
+go test -v -timeout 120m github.com/appgate/terraform-provider-appgate-sdp/appgate -run '^(TestAccApplianceBasicController)$'
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/appgate/terraform-provider-appgate
+module github.com/appgate/terraform-provider-appgate-sdp
 
 go 1.13
 

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"github.com/appgate/terraform-provider-appgate/appgate"
+	"github.com/appgate/terraform-provider-appgate-sdp/appgate"
 )
 
 func main() {


### PR DESCRIPTION
this fixes #101 , we recently changed the name of the github repository but not the go mod name reference.